### PR TITLE
Update Notion data source queries

### DIFF
--- a/notion2markdown/notion.py
+++ b/notion2markdown/notion.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from pathlib import Path
 import json
-from itertools import chain
 from typing import List, Union, Optional
 from .utils import logger, normalize_id
 
@@ -83,7 +82,8 @@ class NotionIO:
 
 class NotionClient:
     def __init__(self, token: str, transformer, filter: Optional[dict]=None):
-        self.client = Client(auth=token)
+        # NOTE: The 2025-09-03 API version requires data source aware calls.
+        self.client = Client(auth=token, notion_version="2025-09-03")
         self.transformer = transformer
         self.filter = filter
 
@@ -94,9 +94,7 @@ class NotionClient:
     def get_blocks(self, block_id: int) -> List:
         """Get all page blocks as json. Recursively fetches descendants."""
         blocks = []
-        for child in chain(
-            *paginate(self.client.blocks.children.list, block_id=block_id)
-        ):
+        for child in paginate(self.client.blocks.children.list, block_id=block_id):
             child["children"] = (
                 list(self.get_blocks(child["id"])) if child["has_children"] else []
             )
@@ -105,15 +103,38 @@ class NotionClient:
 
     def get_database(self, database_id: str) -> List:
         """Fetch pages in database as json."""
-        if self.filter:
+        # -- Step 1 ---------------------------------------------------------
+        # Retrieve the data sources for this database. The first entry is the
+        # original database source which mirrors the legacy behaviour.
+        database = self.client.databases.retrieve(database_id=database_id)
+        data_sources = database.get("data_sources", [])
+
+        if not data_sources:
+            # Fall back to the legacy database query if the account has not yet
+            # migrated. This keeps the change minimally invasive.
             results = paginate(
                 self.client.databases.query,
                 database_id=database_id,
-                filter=self.filter,
+                **({"filter": self.filter} if self.filter else {}),
             )
-        else:
-            results = paginate(
-                self.client.databases.query,
-                database_id=database_id,
+            return list(self.transformer.forward(results))
+
+        data_source_id = data_sources[0]["id"]
+
+        # -- Step 2 ---------------------------------------------------------
+        # Query the new data source endpoint. The request mirrors the legacy
+        # paginate() usage so downstream code can remain unchanged.
+        def query_data_source(start_cursor=None):
+            body = {}
+            if self.filter:
+                body["filter"] = self.filter
+            if start_cursor:
+                body["start_cursor"] = start_cursor
+            return self.client.request(
+                path=f"data_sources/{data_source_id}/query",
+                method="POST",
+                body=body or {},
             )
-        return list(self.transformer.forward(chain(*results)))
+
+        results = paginate(query_data_source)
+        return list(self.transformer.forward(results))


### PR DESCRIPTION
## Summary
- upgrade the Notion client to the 2025-09-03 API version required for data source queries
- add a discovery step to fetch data_source_id and query databases through the new endpoint while retaining a legacy fallback
- fix block pagination to iterate results without flattening dictionary keys

## Testing
- python example.py
- python -m compileall notion2markdown

<code>
Request: GET https://api.notion.com/v1/pages/f8deb4d042034c6c8d03b6de37a99498 "HTTP/1.1 200 OK"
 * Exported to md/f8deb4d042034c6c8d03b6de37a99498.md
</code>

------
https://chatgpt.com/codex/tasks/task_e_68e06efba360832a8b79d5a6b509972c